### PR TITLE
Fix network interface detection

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -24,7 +24,7 @@ if [[ ! -c /dev/net/tun ]]; then
 fi
 
 # Find network interface (usually eth0/1 or wlan0)
-iface=$(sudo cat /etc/yunohost/interface)
+iface=$(sudo route | grep '^default' | grep -o '[^ ]*$')
 
 # Check port availability
 sudo yunohost app checkport 1194


### PR DESCRIPTION
The file `/etc/yunohost/interfaces` is not created anymore, so the detection of the default network interface fails.

Replace it with another method to detect the default network interface.

Fix https://dev.yunohost.org/issues/484 (and probably many other tracked openvpn_ynh issues).
